### PR TITLE
Implement Pinfu check and tests

### DIFF
--- a/src/hand.rs
+++ b/src/hand.rs
@@ -24,6 +24,11 @@ impl Hand {
         }
     }
 
+    /// ツモった牌を返す
+    pub fn drawn(&self) -> Option<Tile> {
+        self.drawn
+    }
+
     /// 手牌をソートする
     pub fn sort(&mut self) {
         self.tiles.sort();

--- a/src/hand_info/hand_analyzer.rs
+++ b/src/hand_info/hand_analyzer.rs
@@ -52,9 +52,9 @@ impl HandAnalyzer {
     /// # Examples
     ///
     /// ```
-    /// use mahjong_rs::hand::*;
-    /// use mahjong_rs::hand_info::hand_analyzer::*;
-    /// use mahjong_rs::winning_hand::name::*;
+    /// use riichi_mahjong_rs::hand::*;
+    /// use riichi_mahjong_rs::hand_info::hand_analyzer::*;
+    /// use riichi_mahjong_rs::winning_hand::name::*;
     ///
     /// // 通常型で和了る
     /// let nm_test_str = "222333444666s6z 6z";
@@ -80,9 +80,9 @@ impl HandAnalyzer {
     /// # Examples
     ///
     /// ```
-    /// use mahjong_rs::hand::*;
-    /// use mahjong_rs::hand_info::hand_analyzer::*;
-    /// use mahjong_rs::winning_hand::name::*;
+    /// use riichi_mahjong_rs::hand::*;
+    /// use riichi_mahjong_rs::hand_info::hand_analyzer::*;
+    /// use riichi_mahjong_rs::winning_hand::name::*;
     ///
     /// // 国士無双で和了る
     /// let to_test_str = "19m19p19s1234567z 1m";

--- a/src/hand_info/status.rs
+++ b/src/hand_info/status.rs
@@ -1,4 +1,4 @@
-use crate::tile::Wind;
+use crate::tile::{Tile, TileSummarize, TileType, Wind};
 
 /// 手牌の（牌以外の）状態
 pub struct Status {
@@ -27,4 +27,42 @@ impl Status {
             prevailing_wind: Wind::East,
         }
     }
+}
+
+/// 与えられた牌と手牌の構成から両面待ちか判定する
+pub fn is_two_sided_wait(tile: TileType, counts: &TileSummarize) -> bool {
+    // 字牌は両面待ちになり得ない
+    if !(Tile::M1..=Tile::S9).contains(&tile) {
+        return false;
+    }
+
+    let offset = if (Tile::M1..=Tile::M9).contains(&tile) {
+        tile - Tile::M1 + 1
+    } else if (Tile::P1..=Tile::P9).contains(&tile) {
+        tile - Tile::P1 + 1
+    } else {
+        tile - Tile::S1 + 1
+    };
+
+    // 左側が存在する形 : xx[tile-2][tile-1] + tile かつ123または789にならない
+    if offset >= 3
+        && counts[(tile - 1) as usize] > 0
+        && counts[(tile - 2) as usize] > 0
+        && offset != 3
+        && offset != 9
+    {
+        return true;
+    }
+
+    // 右側が存在する形 : tile + [tile+1][tile+2] かつ123または789にならない
+    if offset <= 7
+        && counts[(tile + 1) as usize] > 0
+        && counts[(tile + 2) as usize] > 0
+        && offset != 1
+        && offset != 7
+    {
+        return true;
+    }
+
+    false
 }

--- a/src/winning_hand/check_1_han.rs
+++ b/src/winning_hand/check_1_han.rs
@@ -4,7 +4,7 @@ use crate::hand_info::block::BlockProperty;
 use crate::hand_info::hand_analyzer::*;
 use crate::hand_info::status::*;
 use crate::settings::*;
-use crate::tile::{Dragon, Tile, TileType, TileSummarize};
+use crate::tile::{Dragon, Tile, TileSummarize};
 use crate::hand::Hand;
 use crate::winning_hand::name::*;
 

--- a/src/winning_hand/check_1_han.rs
+++ b/src/winning_hand/check_1_han.rs
@@ -4,7 +4,8 @@ use crate::hand_info::block::BlockProperty;
 use crate::hand_info::hand_analyzer::*;
 use crate::hand_info::status::*;
 use crate::settings::*;
-use crate::tile::Dragon;
+use crate::tile::{Dragon, Tile, TileType, TileSummarize};
+use crate::hand::Hand;
 use crate::winning_hand::name::*;
 
 /// 立直
@@ -167,7 +168,70 @@ pub fn check_no_points_hand(
     if !has_won(hand) {
         return Ok((name, false, 0));
     }
-    todo!()
+    // 平和は門前でのみ成立
+    if status.has_claimed_open {
+        return Ok((name, false, 0));
+    }
+    // 面子はすべて順子で構成されているか
+    if hand.same3.len() > 0 || hand.sequential3.len() != 4 || hand.same2.len() != 1 {
+        return Ok((name, false, 0));
+    }
+    // 雀頭が役牌でないこと
+    if let Some(head) = hand.same2.get(0) {
+        if head.has_wind(status.player_wind)?
+            || head.has_wind(status.prevailing_wind)?
+            || head.has_dragon(Dragon::White)?
+            || head.has_dragon(Dragon::Green)?
+            || head.has_dragon(Dragon::Red)?
+        {
+            return Ok((name, false, 0));
+        }
+    } else {
+        return Ok((name, false, 0));
+    }
+
+    // 両面待ちかどうかを確認
+    let mut counts: TileSummarize = [0; Tile::LEN];
+    for seq in &hand.sequential3 {
+        for t in &seq.get() {
+            counts[*t as usize] += 1;
+        }
+    }
+    for pair in &hand.same2 {
+        for t in &pair.get() {
+            counts[*t as usize] += 1;
+        }
+    }
+
+    let mut is_ryanmen = false;
+    for t in Tile::M1..=Tile::Z7 {
+        if counts[t as usize] == 0 {
+            continue;
+        }
+        counts[t as usize] -= 1;
+        // 組み合わせが成立しているか
+        let mut tiles: Vec<Tile> = Vec::new();
+        for i in Tile::M1..=Tile::Z7 {
+            for _ in 0..counts[i as usize] {
+                tiles.push(Tile::new(i));
+            }
+        }
+        let temp_hand = Hand::new(tiles, None);
+        if let Ok(an) = HandAnalyzer::new(&temp_hand) {
+            if an.shanten == 0 && is_two_sided_wait(t, &counts) {
+                is_ryanmen = true;
+                counts[t as usize] += 1;
+                break;
+            }
+        }
+        counts[t as usize] += 1;
+    }
+
+    if !is_ryanmen {
+        return Ok((name, false, 0));
+    }
+
+    Ok((name, true, 1))
 }
 /// 一盃口
 pub fn check_one_set_of_identical_sequences(
@@ -581,6 +645,88 @@ mod tests {
         assert_eq!(
             check_one_set_of_identical_sequences(&test_analyzer, &status, &settings).unwrap(),
             ("一盃口", false, 0)
+        );
+    }
+    #[test]
+    /// 平和で和了った
+    fn test_win_by_no_points_hand() {
+        let test_str = "123567m234p6799s 5s";
+        let test = Hand::from(test_str);
+        let analyzer = HandAnalyzer::new(&test).unwrap();
+        let status = Status::new();
+        let settings = Settings::new();
+        assert_eq!(
+            check_no_points_hand(&analyzer, &status, &settings).unwrap(),
+            ("平和", true, 1)
+        );
+    }
+    #[test]
+    /// 鳴いていると平和にならない
+    fn test_not_win_by_no_points_hand_with_open() {
+        let test_str = "123567m6799s 234p 5s";
+        let test = Hand::from(test_str);
+        let analyzer = HandAnalyzer::new(&test).unwrap();
+        let mut status = Status::new();
+        let settings = Settings::new();
+        status.has_claimed_open = true;
+        assert_eq!(
+            check_no_points_hand(&analyzer, &status, &settings).unwrap(),
+            ("平和", false, 0)
+        );
+    }
+    #[test]
+    /// 刻子が含まれると平和にならない
+    fn test_not_win_by_no_points_hand_with_triplet() {
+        let test_str = "123456m789p222s3s 3s";
+        let test = Hand::from(test_str);
+        let analyzer = HandAnalyzer::new(&test).unwrap();
+        let status = Status::new();
+        let settings = Settings::new();
+        assert_eq!(
+            check_no_points_hand(&analyzer, &status, &settings).unwrap(),
+            ("平和", false, 0)
+        );
+    }
+    #[test]
+    /// 両面待ちでないと平和にならない（辺張待ち）
+    fn test_not_win_by_no_points_hand_with_edge_wait() {
+        let test_str = "12567m234p56799s 3m";
+        let test = Hand::from(test_str);
+        let analyzer = HandAnalyzer::new(&test).unwrap();
+        let status = Status::new();
+        let settings = Settings::new();
+        assert_eq!(
+            check_no_points_hand(&analyzer, &status, &settings).unwrap(),
+            ("平和", false, 0)
+        );
+    }
+
+    #[test]
+    /// 両面待ちでないと平和にならない（嵌張待ち）
+    fn test_not_win_by_no_points_hand_with_closed_wait() {
+        let test_str = "123567m234p5799s 6s";
+        let test = Hand::from(test_str);
+        let analyzer = HandAnalyzer::new(&test).unwrap();
+        let status = Status::new();
+        let settings = Settings::new();
+        assert_eq!(
+            check_no_points_hand(&analyzer, &status, &settings).unwrap(),
+            ("平和", false, 0)
+        );
+    }
+    #[test]
+    /// 雀頭が役牌だと平和にならない
+    fn test_not_win_by_no_points_hand_with_honor_pair() {
+        let test_str = "123567m234p67s11z 8s";
+        let test = Hand::from(test_str);
+        let analyzer = HandAnalyzer::new(&test).unwrap();
+        let mut status = Status::new();
+        let settings = Settings::new();
+        status.player_wind = Wind::East;
+        status.prevailing_wind = Wind::East;
+        assert_eq!(
+            check_no_points_hand(&analyzer, &status, &settings).unwrap(),
+            ("平和", false, 0)
         );
     }
     #[test]

--- a/src/winning_hand/check_3_han.rs
+++ b/src/winning_hand/check_3_han.rs
@@ -4,7 +4,7 @@ use crate::hand_info::block::BlockProperty;
 use crate::hand_info::hand_analyzer::*;
 use crate::hand_info::status::*;
 use crate::settings::*;
-use crate::tile::{TileType, Tile};
+use crate::tile::TileType;
 use crate::winning_hand::name::*;
 
 /// 二盃口

--- a/src/winning_hand/check_6_han.rs
+++ b/src/winning_hand/check_6_han.rs
@@ -4,7 +4,6 @@ use crate::hand_info::block::BlockProperty;
 use crate::hand_info::hand_analyzer::*;
 use crate::hand_info::status::*;
 use crate::settings::*;
-use crate::tile::Tile;
 use crate::winning_hand::name::*;
 
 /// 清一色

--- a/src/winning_hand/check_yakuman.rs
+++ b/src/winning_hand/check_yakuman.rs
@@ -215,7 +215,7 @@ pub fn check_all_green(
     }
     const GREEN: [TileType; 6] = [Tile::S2, Tile::S3, Tile::S4, Tile::S6, Tile::S8, Tile::Z6];
 
-    let mut is_green = |t: TileType| GREEN.contains(&t);
+    let is_green = |t: TileType| GREEN.contains(&t);
 
     for same in &hand.same3 {
         let tile = same.get()[0];

--- a/src/winning_hand/checker.rs
+++ b/src/winning_hand/checker.rs
@@ -5,6 +5,7 @@ use strum::{EnumCount, IntoEnumIterator};
 
 use crate::hand_info::hand_analyzer::HandAnalyzer;
 use crate::hand_info::status::Status;
+use crate::hand::Hand;
 use crate::settings::*;
 use crate::winning_hand::check_1_han::*;
 use crate::winning_hand::check_2_han::*;
@@ -15,7 +16,8 @@ use crate::winning_hand::check_yakuman::*;
 use crate::winning_hand::name::*;
 
 pub fn check(
-    hand: &HandAnalyzer,
+    analyzer: &HandAnalyzer,
+    hand: &Hand,
     status: &Status,
     settings: &Settings,
 ) -> Result<HashMap<Kind, (&'static str, bool, u32)>> {
@@ -27,209 +29,209 @@ pub fn check(
     // 立直
     result.insert(
         Kind::ReadyHand,
-        check_ready_hand(hand, status, settings)?,
+        check_ready_hand(analyzer, status, settings)?,
     );
     // 七対子
     result.insert(
         Kind::SevenPairs,
-        check_seven_pairs(hand, status, settings)?,
+        check_seven_pairs(analyzer, status, settings)?,
     );
     // 流し満貫
     result.insert(
         Kind::NagashiMangan,
-        check_nagashi_mangan(hand, status, settings)?,
+        check_nagashi_mangan(analyzer, status, settings)?,
     );
     // 門前清自摸和
     result.insert(
         Kind::SelfPick,
-        check_self_pick(hand, status, settings)?,
+        check_self_pick(analyzer, status, settings)?,
     );
     // 一発
     result.insert(
         Kind::OneShot,
-        check_one_shot(hand, status, settings)?,
+        check_one_shot(analyzer, status, settings)?,
     );
     // 海底撈月
     result.insert(
         Kind::LastTileFromTheWall,
-        check_last_tile_from_the_wall(hand, status, settings)?,
+        check_last_tile_from_the_wall(analyzer, status, settings)?,
     );
     // 河底撈魚
     result.insert(
         Kind::LastDiscard,
-        check_last_discard(hand, status, settings)?,
+        check_last_discard(analyzer, status, settings)?,
     );
     // 嶺上開花
     result.insert(
         Kind::DeadWallDraw,
-        check_dead_wall_draw(hand, status, settings)?,
+        check_dead_wall_draw(analyzer, status, settings)?,
     );
     // 搶槓
     result.insert(
         Kind::RobbingAQuad,
-        check_robbing_a_quad(hand, status, settings)?,
+        check_robbing_a_quad(analyzer, status, settings)?,
     );
     // ダブル立直
     result.insert(
         Kind::DoubleReady,
-        check_double_ready(hand, status, settings)?,
+        check_double_ready(analyzer, status, settings)?,
     );
     // 平和
     result.insert(
         Kind::NoPointsHand,
-        check_no_points_hand(hand, status, settings)?,
+        check_no_points_hand(analyzer, hand, status, settings)?,
     );
     // 一盃口
     result.insert(
         Kind::OneSetOfIdenticalSequences,
-        check_one_set_of_identical_sequences(hand, status, settings)?,
+        check_one_set_of_identical_sequences(analyzer, status, settings)?,
     );
     // 三色同順
     result.insert(
         Kind::ThreeColourStraight,
-        check_three_colour_straight(hand, status, settings)?,
+        check_three_colour_straight(analyzer, status, settings)?,
     );
     // 一気通貫
     result.insert(
         Kind::Straight,
-        check_straight(hand, status, settings)?,
+        check_straight(analyzer, status, settings)?,
     );
     // 二盃口
     result.insert(
         Kind::TwoSetsOfIdenticalSequences,
-        check_two_sets_of_identical_sequences(hand, status, settings)?,
+        check_two_sets_of_identical_sequences(analyzer, status, settings)?,
     );
     // 対々和
     result.insert(
         Kind::AllTripletHand,
-        check_all_triplet_hand(hand, status, settings)?,
+        check_all_triplet_hand(analyzer, status, settings)?,
     );
     // 三暗刻
     result.insert(
         Kind::ThreeClosedTriplets,
-        check_three_closed_triplets(hand, status, settings)?,
+        check_three_closed_triplets(analyzer, status, settings)?,
     );
     // 三色同刻
     result.insert(
         Kind::ThreeColourTriplets,
-        check_three_colour_triplets(hand, status, settings)?,
+        check_three_colour_triplets(analyzer, status, settings)?,
     );
     // 断么九
     result.insert(
         Kind::AllSimples,
-        check_all_simples(hand, status, settings)?,
+        check_all_simples(analyzer, status, settings)?,
     );
     // 役牌（自風牌）
     result.insert(
         Kind::HonorTilesPlayersWind,
-        check_honor_tiles_players_wind(hand, status, settings)?,
+        check_honor_tiles_players_wind(analyzer, status, settings)?,
     );
     // 役牌（場風牌）
     result.insert(
         Kind::HonorTilesPrevailingWind,
-        check_honor_tiles_prevailing_wind(hand, status, settings)?,
+        check_honor_tiles_prevailing_wind(analyzer, status, settings)?,
     );
     // 役牌（白）
     result.insert(
         Kind::HonorTilesWhiteDragon,
-        check_honor_tiles_white_dragon(hand, status, settings)?,
+        check_honor_tiles_white_dragon(analyzer, status, settings)?,
     );
     // 役牌（發）
     result.insert(
         Kind::HonorTilesGreenDragon,
-        check_honor_tiles_green_dragon(hand, status, settings)?,
+        check_honor_tiles_green_dragon(analyzer, status, settings)?,
     );
     // 役牌（中）
     result.insert(
         Kind::HonorTilesRedDragon,
-        check_honor_tiles_red_dragon(hand, status, settings)?,
+        check_honor_tiles_red_dragon(analyzer, status, settings)?,
     );
     // 混全帯么九
     result.insert(
         Kind::TerminalOrHonorInEachSet,
-        check_terminal_or_honor_in_each_set(hand, status, settings)?,
+        check_terminal_or_honor_in_each_set(analyzer, status, settings)?,
     );
     result.insert(
         Kind::TerminalInEachSet,
-        check_terminal_in_each_set(hand, status, settings)?,
+        check_terminal_in_each_set(analyzer, status, settings)?,
     );
     // 混老頭
     result.insert(
         Kind::AllTerminalsAndHonors,
-        check_all_terminals_and_honors(hand, status, settings)?,
+        check_all_terminals_and_honors(analyzer, status, settings)?,
     );
     // 小三元
     result.insert(
         Kind::LittleThreeDragons,
-        check_little_three_dragons(hand, status, settings)?,
+        check_little_three_dragons(analyzer, status, settings)?,
         // 純全帯么九
     );
     // 混一色
     result.insert(
         Kind::HalfFlush,
-        check_half_flush(hand, status, settings)?,
+        check_half_flush(analyzer, status, settings)?,
     );
     // 清一色
-    result.insert(Kind::Flush, check_flush(hand, status, settings)?);
+    result.insert(Kind::Flush, check_flush(analyzer, status, settings)?);
     // 国士無双
     result.insert(
         Kind::ThirteenOrphans,
-        check_thirteen_orphans(hand, status, settings)?,
+        check_thirteen_orphans(analyzer, status, settings)?,
     );
     // 四暗刻
     result.insert(
         Kind::FourConcealedTriplets,
-        check_four_concealed_triplets(hand, status, settings)?,
+        check_four_concealed_triplets(analyzer, status, settings)?,
     );
     // 大三元
     result.insert(
         Kind::BigThreeDragons,
-        check_big_three_dragons(hand, status, settings)?,
+        check_big_three_dragons(analyzer, status, settings)?,
     );
     // 小四喜
     result.insert(
         Kind::LittleFourWinds,
-        check_little_four_winds(hand, status, settings)?,
+        check_little_four_winds(analyzer, status, settings)?,
     );
     // 大四喜
     result.insert(
         Kind::BigFourWinds,
-        check_big_four_winds(hand, status, settings)?,
+        check_big_four_winds(analyzer, status, settings)?,
     );
     // 字一色
     result.insert(
         Kind::AllHonors,
-        check_all_honors(hand, status, settings)?,
+        check_all_honors(analyzer, status, settings)?,
     );
     // 清老頭
     result.insert(
         Kind::AllTerminals,
-        check_all_terminals(hand, status, settings)?,
+        check_all_terminals(analyzer, status, settings)?,
     );
     // 緑一色
     result.insert(
         Kind::AllGreen,
-        check_all_green(hand, status, settings)?,
+        check_all_green(analyzer, status, settings)?,
     );
     // 九蓮宝燈
     result.insert(
         Kind::NineGates,
-        check_nine_gates(hand, status, settings)?,
+        check_nine_gates(analyzer, status, settings)?,
     );
     // 四槓子
     result.insert(
         Kind::FourKans,
-        check_four_kans(hand, status, settings)?,
+        check_four_kans(analyzer, status, settings)?,
     );
     // 天和
     result.insert(
         Kind::HeavenlyHand,
-        check_heavenly_hand(hand, status, settings)?,
+        check_heavenly_hand(analyzer, status, settings)?,
     );
     // 地和
     result.insert(
         Kind::HandOfEarth,
-        check_hand_of_earth(hand, status, settings)?,
+        check_hand_of_earth(analyzer, status, settings)?,
     );
 
     Ok(result)

--- a/src/winning_hand/name.rs
+++ b/src/winning_hand/name.rs
@@ -114,8 +114,8 @@ pub enum Kind {
 /// # Examples
 ///
 /// ```
-/// use mahjong_rs::settings::Lang;
-/// use mahjong_rs::winning_hand::name::*;
+/// use riichi_mahjong_rs::settings::Lang;
+/// use riichi_mahjong_rs::winning_hand::name::*;
 ///
 /// assert_eq!(get(Kind::ThreeColourStraight, true, Lang::Ja), "三色同順（鳴）");
 /// assert_eq!(get(Kind::ThreeColourStraight, false, Lang::Ja), "三色同順");


### PR DESCRIPTION
## Summary
- update Pinfu helper `is_two_sided_wait` to avoid edge sequences
- tweak Pinfu tests and add edge/closed wait cases

## Testing
- `cargo test --lib --quiet` *(fails: test_not_win_by_no_points_hand_with_closed_wait, test_not_win_by_no_points_hand_with_edge_wait)*

------
https://chatgpt.com/codex/tasks/task_e_684d26339b48832f862ac50d402827fb